### PR TITLE
Fix infinite loop bug when iterating NodeBuiltin

### DIFF
--- a/avl.go
+++ b/avl.go
@@ -104,7 +104,7 @@ func (i *IteratorBuiltin[K, V]) Done() bool {
 }
 
 func (i *IteratorBuiltin[K, V]) Next() {
-	i.i.Done()
+	i.i.Next()
 }
 
 func (i *IteratorBuiltin[K, V]) GetKey() K {

--- a/avl_test.go
+++ b/avl_test.go
@@ -267,6 +267,28 @@ func TestIterator(t *testing.T) {
 	require.Equal(t, valuesFromEntries, valuesFromIterator)
 }
 
+func TestIteratorBuiltin(t *testing.T) {
+	var tree NodeBuiltin[int, int]
+	N := 100
+	for i := 0; i < N; i++ {
+		tree = tree.Insert(i, i)
+	}
+
+	valuesFromEntries := make([]int, N)
+	for i, entry := range tree.Entries() {
+		valuesFromEntries[i] = entry.V
+	}
+
+	keysFromIterator := make([]int, 0, N)
+	valuesFromIterator := make([]int, 0, N)
+	for iter := tree.Iterate(); !iter.Done(); iter.Next() {
+		keysFromIterator = append(keysFromIterator, iter.GetKey().value)
+		valuesFromIterator = append(valuesFromIterator, iter.GetValue())
+	}
+	require.Equal(t, valuesFromEntries, keysFromIterator)
+	require.Equal(t, valuesFromEntries, valuesFromIterator)
+}
+
 func TestIteratorReverse(t *testing.T) {
 	var tree *Node[Builtin[int], int]
 	N := 100


### PR DESCRIPTION
There was a typo in `IteratorBuiltin.Next()` method. It calls the underlying `Done()` method instead of `Next()`

This results in the iterator continually returning the first element in an infinite loop. Minimal example: https://go.dev/play/p/JhEg7HJvPKe